### PR TITLE
chore: add missing output parser func for dissoaciate token, fix e2e associate and dissociate token

### DIFF
--- a/python/hedera_agent_kit_py/plugins/core_token_plugin/associate_token.py
+++ b/python/hedera_agent_kit_py/plugins/core_token_plugin/associate_token.py
@@ -30,6 +30,7 @@ from hedera_agent_kit_py.shared.strategies.tx_mode_strategy import (
     handle_transaction,
 )
 from hedera_agent_kit_py.shared.tool import Tool
+from hedera_agent_kit_py.shared.utils.default_tool_output_parsing import transaction_tool_output_parser
 from hedera_agent_kit_py.shared.utils.prompt_generator import PromptGenerator
 
 
@@ -135,6 +136,7 @@ class AssociateTokenTool(Tool):
         self.name: str = "Associate Token(s)"
         self.description: str = associate_token_prompt(context)
         self.parameters: type[AssociateTokenParameters] = AssociateTokenParameters
+        self.outputParser = transaction_tool_output_parser
 
     async def execute(
         self, client: Client, context: Context, params: AssociateTokenParameters


### PR DESCRIPTION
**Description**:
By mistake d2d tests for both token associate and dissociate were integration tests and not the e2e tests
Also the associate token tool was missing the output parser method

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
