### PR TITLE
chore: Update CODEOWNERS to add platform-ci-committers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,16 +5,16 @@
 *                                       @hashgraph/developer-relations @hashgraph/hedera-agent-kit-maintainers
 
 # Protection Rules for Github Configuration Files and Actions Workflows
-/.github/                               @hashgraph/platform-ci @hashgraph/release-engineering-managers
-/.github/workflows/                     @hashgraph/platform-ci @hashgraph/release-engineering-managers
+/.github/                               @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers
+/.github/workflows/                     @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers
 
 # Self-protection for root CODEOWNERS files (this file should not exist and should definitely require approval)
 /CODEOWNERS                             @hashgraph/release-engineering-managers
 
 # Protect the repository root files
-/README.md                              @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/developer-relations @hashgraph/hedera-agent-kit
+/README.md                              @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers @hashgraph/developer-relations @hashgraph/hedera-agent-kit-maintainers
 **/LICENSE                              @hashgraph/release-engineering-managers
 
 # Git Ignore definitions
-**/.gitignore                           @hashgraph/platform-ci @hashgraph/release-engineering-managers
-**/.gitignore.*                         @hashgraph/platform-ci @hashgraph/release-engineering-managers
+**/.gitignore                           @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers
+**/.gitignore.*                         @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers


### PR DESCRIPTION
**Description**:

Update the CODEOWNERS file to add `hashgraph/platform-ci-committers` to some paths.