### PR TITLE
feat: add factory contract ID handling and deploy address resolution

### DIFF
--- a/docs/HEDERAPLUGINS.md
+++ b/docs/HEDERAPLUGINS.md
@@ -125,6 +125,7 @@ and ERC-721 tokens via on-chain factory contracts.
 | [`CREATE_ERC20_TOOL`](./HEDERATOOLS.md#create_erc20_tool)       | Deploy an ERC-20 token  | [View Parameters & Examples](./HEDERATOOLS.md#create_erc20_tool)    |
 | [`TRANSFER_ERC20_TOOL`](./HEDERATOOLS.md#transfer_erc20_tool)   | Transfer ERC-20 tokens  | [View Parameters & Examples](./HEDERATOOLS.md#transfer_erc20_tool)  |
 | [`CREATE_ERC721_TOOL`](./HEDERATOOLS.md#create_erc721_tool)     | Deploy an ERC-721 NFT   | [View Parameters & Examples](./HEDERATOOLS.md#create_erc721_tool)   |
+| [`MINT_ERC721_TOOL`](./HEDERATOOLS.md#mint_erc721_tool)         | Mint an ERC-721 NFT     | [View Parameters & Examples](./HEDERATOOLS.md#mint_erc721_tool)     |
 | [`TRANSFER_ERC721_TOOL`](./HEDERATOOLS.md#transfer_erc721_tool) | Transfer an ERC-721 NFT | [View Parameters & Examples](./HEDERATOOLS.md#transfer_erc721_tool) |
 
 ---

--- a/docs/HEDERATOOLS.md
+++ b/docs/HEDERATOOLS.md
@@ -48,6 +48,7 @@ For a high-level overview of available plugins, see [HEDERAPLUGINS.md](./HEDERAP
   - [CREATE_ERC20_TOOL](#create_erc20_tool)
   - [TRANSFER_ERC20_TOOL](#transfer_erc20_tool)
   - [CREATE_ERC721_TOOL](#create_erc721_tool)
+  - [MINT_ERC721_TOOL](#mint_erc721_tool)
   - [TRANSFER_ERC721_TOOL](#transfer_erc721_tool)
 - [EVM Query Tools](#evm-query-tools)
   - [GET_CONTRACT_INFO_QUERY_TOOL](#get_contract_info_query_tool)
@@ -742,10 +743,13 @@ Transfer ERC-20 tokens.
 #### Parameters
 
 | Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
+|-----------|------|----------|--------------|
 | `contract_id` | `str` | ✅ | ERC-20 contract ID (EVM address or Hedera ID). |
 | `recipient_address` | `str` | ✅ | Recipient address (EVM or Hedera ID). |
-| `amount` | `int` | ✅ | Amount to transfer (base units). |
+| `amount` | `int` | ✅ | Amount to transfer in **base units** (smallest denomination, e.g., for 18 decimals: 1 token = 10^18 base units). |
+
+> [!IMPORTANT]
+> The `amount` parameter accepts values in **base units** (the smallest token denomination), not display units. For example, if the token has 18 decimals and you want to transfer 1 token, you must pass `1000000000000000000` (10^18).
 
 #### Example Prompts
 
@@ -777,6 +781,27 @@ Create an ERC721 collection called ArtDrops with symbol AD and base URI ipfs://Q
 
 ---
 
+### MINT_ERC721_TOOL
+
+Mint a new ERC-721 NFT by calling the `safeMint(to)` function on the contract.
+
+#### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `contract_id` | `str` | ✅ | - | The ID of the ERC-721 contract (EVM address or Hedera ID). |
+| `to_address` | `str` | ❌ | operator | Address to which the token will be minted. |
+
+#### Example Prompts
+
+```
+Mint ERC721 token 0.0.6486793 to 0xd94dc7f82f103757f715514e4a37186be6e4580b
+Mint ERC721 token 0.0.6486793 to Hedera account ID 0.0.2222222
+Mint ERC721 token 0.0.9999
+```
+
+---
+
 ### TRANSFER_ERC721_TOOL
 
 Transfer an ERC-721 NFT.
@@ -784,16 +809,19 @@ Transfer an ERC-721 NFT.
 #### Parameters
 
 | Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `contract_id` | `str` | ✅ | ERC-721 contract ID. |
+|-----------|------|----------|--------------|
+| `contract_id` | `str` | ✅ | ERC-721 contract ID (EVM address or Hedera ID). |
 | `from_address` | `str` | ❌ | Sender address (defaults to operator). |
-| `to_address` | `str` | ✅ | Recipient address. |
-| `token_id` | `int` | ✅ | Token ID to transfer. |
+| `to_address` | `str` | ✅ | Recipient address (EVM or Hedera ID). |
+| `token_id` | `int` | ✅ | The ID of the specific NFT within the ERC-721 collection to transfer. |
+
+> [!NOTE]
+> In ERC-721 collections, token IDs typically start from **0** (or 1, depending on the contract implementation). The first minted NFT is usually token ID 0.
 
 #### Example Prompts
 
 ```
-Transfer ERC721 token 1 from contract 0.0.12345 to 0.0.67890
+Transfer ERC721 token 0 from contract 0.0.12345 to 0.0.67890
 Send NFT #5 from 0x1234... to 0x5678...
 ```
 

--- a/python/hedera_agent_kit/plugins/core_evm_plugin/create_erc20.py
+++ b/python/hedera_agent_kit/plugins/core_evm_plugin/create_erc20.py
@@ -31,7 +31,7 @@ from hedera_agent_kit.shared.strategies.tx_mode_strategy import (
     handle_transaction,
 )
 from hedera_agent_kit.shared.tool import Tool
-from hedera_agent_kit.shared.utils import ledger_id_from_network
+from hedera_agent_kit.shared.utils import ledger_id_from_network, get_deployed_contract_address
 from hedera_agent_kit.shared.utils.default_tool_output_parsing import (
     transaction_tool_output_parser,
 )
@@ -110,12 +110,19 @@ async def create_erc20(
             return result
 
         raw_tx_data = cast(ExecutedTransactionToolResponse, result).raw
+
+        # move the returned contract ID to the factory contract ID field
+        # sdk for factory calls returns the factory contract ID
+        raw_tx_data.factory_contract_id = raw_tx_data.contract_id
+
         evm_contract_id: str | None = None
 
+        # If transaction is scheduled we can't know the created address yet.
         is_scheduled = getattr(params, "is_scheduled", False)
-        contract_id = getattr(raw_tx_data, "contract_id", None)
-        if not is_scheduled and contract_id:
-            evm_contract_id = f"0x{str(contract_id.to_evm_address())}"
+        if not is_scheduled:
+            evm_contract_id = await get_deployed_contract_address(client, raw_tx_data)
+            # inject the correct contract ID into raw response
+            raw_tx_data.contract_id = evm_contract_id
 
         human_message = post_process(evm_contract_id, raw_tx_data)
 

--- a/python/hedera_agent_kit/plugins/core_evm_plugin/create_erc721.py
+++ b/python/hedera_agent_kit/plugins/core_evm_plugin/create_erc721.py
@@ -11,9 +11,7 @@ from __future__ import annotations
 from typing import cast
 
 from hiero_sdk_python import Client
-from hiero_sdk_python.query.transaction_record_query import TransactionRecordQuery
 from hiero_sdk_python.transaction.transaction import Transaction
-
 from hedera_agent_kit.shared.configuration import Context, AgentMode
 from hedera_agent_kit.shared.constants.contracts import (
     get_erc721_factory_address,
@@ -36,7 +34,7 @@ from hedera_agent_kit.shared.strategies.tx_mode_strategy import (
     handle_transaction,
 )
 from hedera_agent_kit.shared.tool import Tool
-from hedera_agent_kit.shared.utils import ledger_id_from_network
+from hedera_agent_kit.shared.utils import ledger_id_from_network, get_deployed_contract_address
 from hedera_agent_kit.shared.utils.default_tool_output_parsing import (
     transaction_tool_output_parser,
 )
@@ -81,38 +79,6 @@ def post_process(evm_contract_id: str, response: RawTransactionResponse) -> str:
     )
 
 
-async def _get_erc721_address(
-    client: Client, raw: RawTransactionResponse
-) -> str | None:
-    """Minimal helper to resolve the deployed ERC721 EVM address via SDK."""
-
-    record = (
-        TransactionRecordQuery().set_transaction_id(raw.transaction_id).execute(client)
-    )
-
-    contract_call_result = getattr(record, "call_result", None)
-
-    if contract_call_result is None:
-        return None
-
-    # Access the raw ABI-encoded return bytes from the function result
-    result_bytes = getattr(contract_call_result, "contract_call_result", None)
-
-    if not result_bytes or not isinstance(result_bytes, (bytes, bytearray)):
-        return None
-
-    # The factory returns an EVM address as the first return value.
-    # In Solidity ABI, an address is encoded as a 32-byte word left-padded with zeros.
-    # We need to take the last 20 bytes of the first 32-byte word.
-    if len(result_bytes) < 32:
-        return None
-
-    first_word = bytes(result_bytes[:32])
-    addr_last_20 = first_word[-20:]
-    evm_addr = "0x" + addr_last_20.hex()
-    return evm_addr
-
-
 async def create_erc721(
     client: Client,
     context: Context,
@@ -142,12 +108,19 @@ async def create_erc721(
             return result
 
         raw_tx_data = cast(ExecutedTransactionToolResponse, result).raw
+
+        # move the returned contract ID to the factory contract ID field
+        # sdk for factory calls returns the factory contract ID
+        raw_tx_data.factory_contract_id = raw_tx_data.contract_id
+
         evm_contract_id: str | None = None
 
         # If transaction is scheduled we can't know the created address yet.
         is_scheduled = getattr(params, "is_scheduled", False)
         if not is_scheduled:
-            evm_contract_id = await _get_erc721_address(client, raw_tx_data)
+            evm_contract_id = await get_deployed_contract_address(client, raw_tx_data)
+            # inject the correct contract ID into raw response
+            raw_tx_data.contract_id = evm_contract_id
 
         human_message = post_process(evm_contract_id, raw_tx_data)
 

--- a/python/hedera_agent_kit/plugins/core_evm_plugin/mint_erc721.py
+++ b/python/hedera_agent_kit/plugins/core_evm_plugin/mint_erc721.py
@@ -41,7 +41,7 @@ def mint_erc721_prompt(context: Context = {}) -> str:
     context_snippet = PromptGenerator.get_context_snippet(context)
     usage_instructions = PromptGenerator.get_parameter_usage_instructions()
     to_address_desc = PromptGenerator.get_any_address_parameter_description(
-        "toAddress", context, is_required=False
+        "to_address", context, is_required=False
     )
 
     return f"""

--- a/python/hedera_agent_kit/shared/models.py
+++ b/python/hedera_agent_kit/shared/models.py
@@ -40,7 +40,7 @@ class ToolResponse:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "ToolResponse":
-        """Reconstruct from dictionary, keeping unrecognized fields."""
+        """Reconstruct from the dictionary, keeping unrecognized fields."""
         base_keys = {"human_message", "error"}
         extra = {k: v for k, v in data.items() if k not in base_keys}
         return cls(
@@ -61,6 +61,7 @@ class RawTransactionResponse:
     topic_id: Optional[TopicId] = None
     schedule_id: Optional[ScheduleId] = None
     contract_id: Optional[ContractId] = None
+    factory_contract_id: Optional[ContractId] = None
     error: Optional[str] = None
 
     def to_dict(self) -> dict[str, Any]:
@@ -73,6 +74,7 @@ class RawTransactionResponse:
             "topic_id": str(self.topic_id) if self.topic_id else None,
             "schedule_id": str(self.schedule_id) if self.schedule_id else None,
             "contract_id": str(self.contract_id) if self.contract_id else None,
+            "factory_contract_id": str(self.factory_contract_id) if self.factory_contract_id else None,
             "error": self.error,
         }
 
@@ -105,6 +107,11 @@ class RawTransactionResponse:
             contract_id=(
                 ContractId.from_string(data["contract_id"])
                 if data.get("contract_id")
+                else None
+            ),
+            factory_contract_id=(
+                ContractId.from_string(data["factory_contract_id"])
+                if data.get("factory_contract_id")
                 else None
             ),
             error=data.get("error"),

--- a/python/hedera_agent_kit/shared/strategies/tx_mode_strategy.py
+++ b/python/hedera_agent_kit/shared/strategies/tx_mode_strategy.py
@@ -108,6 +108,9 @@ class ExecuteStrategy(TxModeStrategy):
             transaction_id=getattr(receipt, "transaction_id", None),
             topic_id=getattr(receipt, "topic_id", None),
             schedule_id=getattr(receipt, "schedule_id", None),
+            factory_contract_id=None,
+            # In the case of tools like create_erc20 or create_er721, the sdk returns the id of factory contract.
+            # in those situations we rely on the tool to inject the correct contract id and set the factory contract id before returning the response
             contract_id=getattr(receipt, "contract_id", None),
         )
 

--- a/python/hedera_agent_kit/shared/utils/__init__.py
+++ b/python/hedera_agent_kit/shared/utils/__init__.py
@@ -1,3 +1,9 @@
-__all__ = ["ledger_id_from_network", "LedgerId", "network_from_ledger_id"]
+__all__ = [
+    "ledger_id_from_network",
+    "LedgerId",
+    "network_from_ledger_id",
+    "get_deployed_contract_address",
+]
 
 from .ledger_id import ledger_id_from_network, LedgerId, network_from_ledger_id
+from .contract_address_resolver import get_deployed_contract_address

--- a/python/hedera_agent_kit/shared/utils/contract_address_resolver.py
+++ b/python/hedera_agent_kit/shared/utils/contract_address_resolver.py
@@ -1,0 +1,57 @@
+"""Utilities for resolving deployed contract addresses from transaction records.
+
+This module provides helpers to extract the EVM address of contracts deployed
+via factory pattern transactions on Hedera.
+"""
+
+from __future__ import annotations
+
+from hiero_sdk_python import Client
+from hiero_sdk_python.query.transaction_record_query import TransactionRecordQuery
+
+from hedera_agent_kit.shared.models import RawTransactionResponse
+
+
+async def get_deployed_contract_address(
+    client: Client, raw: RawTransactionResponse
+) -> str | None:
+    """Resolve the deployed contract EVM address from a transaction record.
+
+    When a factory contract deploys a new contract (e.g., ERC20 or ERC721),
+    the new contract's address is returned as part of the function result.
+    This helper queries the transaction record and decodes that address from
+    the ABI-encoded return bytes.
+
+    Args:
+        client: The Hedera client used to query the transaction record.
+        raw: The raw transaction response containing the transaction ID.
+
+    Returns:
+        The deployed contract's EVM address as a hex string (e.g., "0x..."),
+        or None if the address could not be resolved.
+    """
+    record = (
+        TransactionRecordQuery().set_transaction_id(raw.transaction_id).execute(client)
+    )
+
+    contract_call_result = getattr(record, "call_result", None)
+
+    if contract_call_result is None:
+        return None
+
+    # Access the raw ABI-encoded return bytes from the function result
+    result_bytes = getattr(contract_call_result, "contract_call_result", None)
+
+    if not result_bytes or not isinstance(result_bytes, (bytes, bytearray)):
+        return None
+
+    # The factory returns an EVM address as the first return value.
+    # In Solidity ABI, an address is encoded as a 32-byte word left-padded with zeros.
+    # We need to take the last 20 bytes of the first 32-byte word.
+    if len(result_bytes) < 32:
+        return None
+
+    first_word = bytes(result_bytes[:32])
+    addr_last_20 = first_word[-20:]
+    evm_addr = "0x" + addr_last_20.hex()
+    return evm_addr


### PR DESCRIPTION
**Description**:
- Introduced `factory_contract_id` field in `RawTransactionResponse` model
- Implemented utility to resolve deployed contract addresses.
- Updated ERC-20 and ERC-721 handling to support factory patterns.
- Enhanced documentation with `MINT_ERC721_TOOL` and additional examples.

**Related issue(s)**:
Fixes #135


**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
