### PR TITLE
docs: add hak-saucerswap-plugin to third party plugins list

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ Want to add more functionality from Hedera Services? [Open an issue](https://git
 
 The Hedera Agent Kit is extensible with third party plugins by other projects. See how you can build and submit your own plugin to listed as a Hedera Agent Kit plugin in [Hedera Docs](https://docs.hedera.com/hedera/open-source-solutions/ai-studio-on-hedera/hedera-ai-agent-kit) and README in [docs/PLUGINS.md](https://github.com/hashgraph/hedera-agent-kit-py/blob/main/docs/PLUGINS.md)
 
+#### Available Third Party Plugins
+
+- [HAK SaucerSwap Plugin](https://pypi.org/project/hak-saucerswap-plugin/) provides a streamlined interface to the [**SaucerSwap**](https://saucerswap.finance) DEX, exposing the core actions (`saucerswap_get_swap_quote`, `saucerswap_swap_tokens`, `saucerswap_get_pools`, `saucerswap_add_liquidity`, `saucerswap_remove_liquidity`, `saucerswap_get_farms`) for swaps, liquidity, and farming insights:
+
+  PyPI: https://pypi.org/project/hak-saucerswap-plugin/
+
+  Github repository: https://github.com/jmgomezl/hak-saucerswap-plugin-py
+
+  Version: hak-saucerswap-plugin==0.1.0
+
+  Status: Not validated by HAK team, BaseToolV2-compatible release
+
 ---
 
 ## Developer Examples


### PR DESCRIPTION
## Description

Adds **hak-saucerswap-plugin** to the third party plugins list, following the submission process in [docs/PLUGINS.md](https://github.com/hashgraph/hedera-agent-kit-py/blob/main/docs/PLUGINS.md). This creates the **Available Third Party Plugins** subsection referenced there (this appears to be the first third-party entry for the Python kit).

The plugin integrates the [SaucerSwap](https://saucerswap.finance) DEX, exposing six tools built on the `BaseToolV2` lifecycle:

- `saucerswap_get_swap_quote` — price quote with min output, price impact, and route (read-only)
- `saucerswap_swap_tokens` — execute a swap via the router contract
- `saucerswap_get_pools` — list/filter liquidity pools and reserves (read-only)
- `saucerswap_add_liquidity` / `saucerswap_remove_liquidity` — manage pool positions
- `saucerswap_get_farms` — list active yield farms (read-only)

It is the Python port of the TypeScript plugin [hak-saucerswap-plugin](https://github.com/jmgomezl/hak-saucerswap-plugin) already listed in the hedera-agent-kit-js registry (validated by the HAK team there).

- PyPI: https://pypi.org/project/hak-saucerswap-plugin/ (`hak-saucerswap-plugin==0.1.0`)
- Repository: https://github.com/jmgomezl/hak-saucerswap-plugin-py (README documents all tools, parameters, and configuration; CI runs lint/tests/build on Python 3.10–3.13)

Commit is DCO signed. Happy to adjust the entry format or status wording, and to have the HAK team test the plugin for validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)