### PR TITLE
Clarify hook policy tool method matching

### DIFF
--- a/docs/HOOKS_AND_POLICIES.md
+++ b/docs/HOOKS_AND_POLICIES.md
@@ -89,7 +89,7 @@ Provides an immutable audit trail by logging tool executions to a Hedera Consens
 
 **Parameters**:
 
-- `relevant_tools`: `List[str]` - List of tools to audit (e.g., `['transfer_hbar', 'create_token']`).
+- `relevant_tools`: `List[str]` - List of exact tool method names to audit (e.g., `['transfer_hbar_tool', 'create_token_tool']`). Tool method names often include the `_tool` suffix; use the constants exported by plugin modules when possible.
 - `hcs_topic_id`: `str` - The pre-created Hedera topic ID (e.g., `'0.0.12345'`).
 
 **Example Usage**:
@@ -99,7 +99,7 @@ from hedera_agent_kit.hooks.hcs_audit_trail_hook import HcsAuditTrailHook
 from hedera_agent_kit.shared.configuration import Context
 
 audit_hook = HcsAuditTrailHook(
-    relevant_tools=['transfer_hbar', 'create_token'],
+    relevant_tools=['transfer_hbar_tool', 'create_token_tool'],
     hcs_topic_id='0.0.12345'
 )
 
@@ -118,17 +118,17 @@ A security policy that limits the number of recipients in transfer and airdrop o
 
 **Default Supported Tools**:
 By default, the policy knows how to count recipients for tools matching the following names:
-- `transfer_hbar`
-- `transfer_hbar_with_allowance`
-- `airdrop_fungible_token`
-- `transfer_fungible_token_with_allowance`
-- `transfer_nft_with_allowance`
-- `transfer_non_fungible_token`
+- `transfer_hbar_tool`
+- `transfer_hbar_with_allowance_tool`
+- `airdrop_fungible_token_tool`
+- `transfer_fungible_token_with_allowance_tool`
+- `transfer_nft_with_allowance_tool`
+- `transfer_non_fungible_token_tool`
 
 **Parameters**:
 
 - `max_recipients`: `int` - Maximum number of recipients allowed.
-- `additional_tools`: `List[str]` - (Optional) Extra tools to apply this policy to.
+- `additional_tools`: `List[str]` - (Optional) Extra exact tool method names to apply this policy to.
 - `custom_strategies`: `Dict[str, Callable[[Any], int]]` - (Optional) A mapping of tool names to functions that count recipients. **If you add tools via `additional_tools`, you must provide a strategy for each one**, otherwise the policy will throw an error at runtime.
 
 **Example with Custom Strategies**:
@@ -161,7 +161,7 @@ A restrictive policy used to explicitly disable specific tools. Even if a tool i
 
 **Parameters**:
 
-- `relevant_tools`: `List[str]` - The list of tool methods to be blocked (e.g., `['delete_account', 'freeze_token']`).
+- `relevant_tools`: `List[str]` - The list of exact tool method names to be blocked (e.g., `['delete_account_tool', 'freeze_token_tool']`).
 
 **Example Usage**:
 
@@ -169,7 +169,7 @@ A restrictive policy used to explicitly disable specific tools. Even if a tool i
 from hedera_agent_kit.policies.reject_tool_policy import RejectToolPolicy
 from hedera_agent_kit.shared.configuration import Context
 
-safety_policy = RejectToolPolicy(['delete_account'])
+safety_policy = RejectToolPolicy(['delete_account_tool'])
 
 context = Context(
     account_id="0.0.1234",
@@ -274,7 +274,7 @@ When a hook targets multiple tools, you handle the various parameter structures 
 async def post_params_normalization_hook(
     self, context: Context, params: PostParamsNormalizationParams, method: str
 ) -> Any:
-    if method in ['transfer_hbar', 'transfer_hbar_with_allowance']:
+    if method in ['transfer_hbar_tool', 'transfer_hbar_with_allowance_tool']:
         # Shared structure logic
         transfers = params.normalized_params['transfers']
         total = sum(t['amount'] for t in transfers)
@@ -311,7 +311,7 @@ class MyCustomHook(AbstractHook):
 
     @property
     def relevant_tools(self) -> list[str]:
-        return ['create_account', 'transfer_hbar']
+        return ['create_account_tool', 'transfer_hbar_tool']
 
     async def pre_tool_execution_hook(
             self, context: Context, params: PreToolExecutionParams, method: str
@@ -344,7 +344,7 @@ class MyCustomPolicy(AbstractPolicy):
 
     @property
     def relevant_tools(self) -> list[str]:
-        return ['transfer_hbar', 'transfer_fungible_token']
+        return ['transfer_hbar_tool', 'transfer_fungible_token_tool']
 
     async def should_block_pre_tool_execution(
             self, context: Context, params: PreToolExecutionParams, method: str
@@ -368,4 +368,4 @@ When adding a new Hook or Policy:
 2. **Export**: Export it in `__init__.py`.
 3. **Documentation**: Add a new section in [Part 1: Available Hooks and Policies](#available-hooks-and-policies).
 4. **Testing**: Add unit tests in the corresponding test directory.
-5. **Update**: Ensure your `relevant_tools` are clearly defined.
+5. **Update**: Ensure your `relevant_tools` are clearly defined with exact tool method names, including suffixes such as `_tool` where the plugin uses them.

--- a/python/hedera_agent_kit/shared/hook.py
+++ b/python/hedera_agent_kit/shared/hook.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
+import logging
 from abc import ABC
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Generic, List, TypeVar
 
-from hiero_sdk_python import Client
-
 if TYPE_CHECKING:
     from hedera_agent_kit.shared.configuration import Context
+    from hiero_sdk_python import Client
 
 TParams = TypeVar("TParams")
 TNormalizedParams = TypeVar("TNormalizedParams")
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -73,22 +75,50 @@ class AbstractHook(ABC):
         self, context: Context, params: PreToolExecutionParams, method: str
     ) -> Any:
         if method not in self.relevant_tools:
+            logger.debug(
+                "%s skipped pre_tool_execution_hook for tool method %r; "
+                "configured relevant_tools=%s",
+                self.name,
+                method,
+                self.relevant_tools,
+            )
             return
 
     async def post_params_normalization_hook(
         self, context: Context, params: PostParamsNormalizationParams, method: str
     ) -> Any:
         if method not in self.relevant_tools:
+            logger.debug(
+                "%s skipped post_params_normalization_hook for tool method %r; "
+                "configured relevant_tools=%s",
+                self.name,
+                method,
+                self.relevant_tools,
+            )
             return
 
     async def post_core_action_hook(
         self, context: Context, params: PostCoreActionParams, method: str
     ) -> Any:
         if method not in self.relevant_tools:
+            logger.debug(
+                "%s skipped post_core_action_hook for tool method %r; "
+                "configured relevant_tools=%s",
+                self.name,
+                method,
+                self.relevant_tools,
+            )
             return
 
     async def post_secondary_action_hook(
         self, context: Context, params: PostSecondaryActionParams, method: str
     ) -> Any:
         if method not in self.relevant_tools:
+            logger.debug(
+                "%s skipped post_secondary_action_hook for tool method %r; "
+                "configured relevant_tools=%s",
+                self.name,
+                method,
+                self.relevant_tools,
+            )
             return

--- a/python/hedera_agent_kit/shared/policy.py
+++ b/python/hedera_agent_kit/shared/policy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from abc import ABC
 from typing import TYPE_CHECKING, Any, List
 
@@ -13,6 +14,8 @@ from hedera_agent_kit.shared.hook import (
 
 if TYPE_CHECKING:
     from .configuration import Context
+
+logger = logging.getLogger(__name__)
 
 
 class AbstractPolicy(AbstractHook, ABC):
@@ -72,6 +75,13 @@ class AbstractPolicy(AbstractHook, ABC):
         self, context: Context, params: PreToolExecutionParams, method: str
     ) -> Any:
         if method not in self.relevant_tools:
+            logger.debug(
+                "%s skipped pre_tool_execution_hook for tool method %r; "
+                "configured relevant_tools=%s",
+                self.name,
+                method,
+                self.relevant_tools,
+            )
             return
 
         should_block = await self.should_block_pre_tool_execution(
@@ -85,6 +95,13 @@ class AbstractPolicy(AbstractHook, ABC):
         self, context: Context, params: PostParamsNormalizationParams, method: str
     ) -> Any:
         if method not in self.relevant_tools:
+            logger.debug(
+                "%s skipped post_params_normalization_hook for tool method %r; "
+                "configured relevant_tools=%s",
+                self.name,
+                method,
+                self.relevant_tools,
+            )
             return
 
         should_block = await self.should_block_post_params_normalization(
@@ -98,6 +115,13 @@ class AbstractPolicy(AbstractHook, ABC):
         self, context: Context, params: PostCoreActionParams, method: str
     ) -> Any:
         if method not in self.relevant_tools:
+            logger.debug(
+                "%s skipped post_core_action_hook for tool method %r; "
+                "configured relevant_tools=%s",
+                self.name,
+                method,
+                self.relevant_tools,
+            )
             return
 
         should_block = await self.should_block_post_core_action(context, params, method)
@@ -109,6 +133,13 @@ class AbstractPolicy(AbstractHook, ABC):
         self, context: Context, params: PostSecondaryActionParams, method: str
     ) -> Any:
         if method not in self.relevant_tools:
+            logger.debug(
+                "%s skipped post_secondary_action_hook for tool method %r; "
+                "configured relevant_tools=%s",
+                self.name,
+                method,
+                self.relevant_tools,
+            )
             return
 
         should_block = await self.should_block_post_secondary_action(

--- a/python/test/unit/policy/policy_method_filtering_test.py
+++ b/python/test/unit/policy/policy_method_filtering_test.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from hedera_agent_kit.shared.hook import PreToolExecutionParams
+from hedera_agent_kit.shared.policy import AbstractPolicy
+
+
+class TrackingPolicy(AbstractPolicy):
+    def __init__(self) -> None:
+        self.calls = 0
+
+    @property
+    def name(self) -> str:
+        return "Tracking Policy"
+
+    @property
+    def relevant_tools(self) -> list[str]:
+        return ["transfer_hbar_tool"]
+
+    async def should_block_pre_tool_execution(
+        self, context: object, params: PreToolExecutionParams, method: str
+    ) -> bool:
+        self.calls += 1
+        return False
+
+
+@pytest.mark.asyncio
+async def test_policy_logs_debug_when_method_name_does_not_match(caplog):
+    policy = TrackingPolicy()
+    context = object()
+    params = MagicMock(spec=PreToolExecutionParams)
+
+    with caplog.at_level(logging.DEBUG):
+        await policy.pre_tool_execution_hook(context, params, "transfer_hbar")
+
+    assert policy.calls == 0
+    assert "skipped pre_tool_execution_hook" in caplog.text
+    assert "transfer_hbar" in caplog.text
+    assert "transfer_hbar_tool" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_policy_runs_when_exact_tool_method_matches(caplog):
+    policy = TrackingPolicy()
+    context = object()
+    params = MagicMock(spec=PreToolExecutionParams)
+
+    with caplog.at_level(logging.DEBUG):
+        await policy.pre_tool_execution_hook(context, params, "transfer_hbar_tool")
+
+    assert policy.calls == 1
+    assert "skipped pre_tool_execution_hook" not in caplog.text


### PR DESCRIPTION
## Summary
- Add debug logging when base hooks/policies skip a lifecycle hook because the runtime tool method is not in `relevant_tools`.
- Move the SDK `Client` import in the base hook behind `TYPE_CHECKING`, since it is only used for annotations.
- Update hook/policy docs to use exact method names such as `transfer_hbar_tool` and call out the `_tool` suffix.
- Add focused policy tests for mismatched versus exact tool method names.

## Validation
- `python -m py_compile python/hedera_agent_kit/shared/hook.py python/hedera_agent_kit/shared/policy.py python/test/unit/policy/policy_method_filtering_test.py`
- `python/.venv/Scripts/python.exe -m pytest -o addopts="" test/unit/policy/policy_method_filtering_test.py test/unit/policy/reject_tool_policy_test.py` - 5 passed

Note: the local test bootstrap attempted to initialize HBAR price service and could not reach `testnet.mirrornode.hedera.com` from this sandbox, but the focused unit tests completed successfully.

Fixes #339
